### PR TITLE
Add support for custom *css.Stylesheet

### DIFF
--- a/inliner/inliner.go
+++ b/inliner/inliner.go
@@ -45,16 +45,21 @@ type Inliner struct {
 }
 
 // NewInliner instanciates a new Inliner
-func NewInliner(html string) *Inliner {
+func NewInliner(html string, styles ...*css.Stylesheet) *Inliner {
+	var st []*css.Stylesheet
+	if len(styles) > 0 {
+		st = append(st, styles...)
+	}
 	return &Inliner{
-		html:     html,
-		elements: make(map[string]*Element),
+		html:        html,
+		elements:    make(map[string]*Element),
+		stylesheets: st,
 	}
 }
 
 // Inline inlines css into html document
-func Inline(html string) (string, error) {
-	result, err := NewInliner(html).Inline()
+func Inline(html string, styles ...*css.Stylesheet) (string, error) {
+	result, err := NewInliner(html, styles...).Inline()
 	if err != nil {
 		return "", err
 	}
@@ -104,6 +109,8 @@ func (inliner *Inliner) parseHTML() error {
 // Parses and removes stylesheets from HTML document
 func (inliner *Inliner) parseStylesheets() error {
 	var result error
+	if len(inliner.stylesheets) > 0 {
+	}
 
 	inliner.doc.Find("style").EachWithBreak(func(i int, s *goquery.Selection) bool {
 		stylesheet, err := parser.Parse(s.Text())

--- a/inliner/inliner_test.go
+++ b/inliner/inliner_test.go
@@ -2,6 +2,9 @@ package inliner
 
 import (
 	"fmt"
+
+	"github.com/aymerick/douceur/parser"
+
 	"testing"
 )
 
@@ -36,6 +39,16 @@ func TestInliner(t *testing.T) {
 
 </body></html>`
 
+	expectedOutputCustom := `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+
+  </head>
+  <body style="color: #eee; font-family: &#39;Helvetica Neue&#39;, Verdana, sans-serif;">
+    <p style="color: #eee; font-family: &#39;Helvetica Neue&#39;, Verdana, sans-serif;">
+      Inline me please!
+    </p>
+
+</body></html>`
 	output, err := Inline(input)
 	if err != nil {
 		t.Fatal("Failed to inline html:", err)
@@ -43,6 +56,25 @@ func TestInliner(t *testing.T) {
 
 	if output != expectedOutput {
 		t.Fatal(fmt.Sprintf("CSS inliner error\nExpected:\n\"%s\"\nGot:\n\"%s\"", expectedOutput, output))
+	}
+
+	inputStyle := `body {
+    font-family: 'Helvetica Neue', Verdana, sans-serif;
+    color: #eee;
+  }
+`
+	st, err := parser.Parse(inputStyle)
+	if err != nil {
+		t.Fatal("Failed to parse css:", err)
+	}
+
+	output, err = Inline(input, st)
+	if err != nil {
+		t.Fatal("Failed to inline html:", err)
+	}
+
+	if output != expectedOutputCustom {
+		t.Fatal(fmt.Sprintf("CSS inliner error\nExpected:\n\"%s\"\nGot:\n\"%s\"", expectedOutputCustom, output))
 	}
 }
 


### PR DESCRIPTION
This extends the API for Inline  to accept optional coma separated list of
*css.Stylesheet.

This enable to inline styles extracted from external sources.
