### PR TITLE
Allow Inline be configured to leave !important css attributes

### DIFF
--- a/douceur.go
+++ b/douceur.go
@@ -17,10 +17,12 @@ const (
 
 var (
 	flagVersion bool
+	keepImportant bool
 )
 
 func init() {
 	flag.BoolVar(&flagVersion, "version", false, "Display version")
+	flag.BoolVar(&keepImportant, "keepImportant", false, "keep !important suffix")
 }
 
 func main() {
@@ -52,7 +54,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		inlineCSS(args[1])
+		inlineCSS(args[1], keepImportant)
 	default:
 		fmt.Println("Unexpected command: ", args[0])
 		os.Exit(1)
@@ -73,10 +75,13 @@ func parseCSS(filePath string) {
 }
 
 // inlines CSS into HTML and display result
-func inlineCSS(filePath string) {
+func inlineCSS(filePath string, keepImportant bool) {
 	input := readFile(filePath)
 
-	output, err := inliner.Inline(string(input))
+	output, err := inliner.InlineWithConfig(
+		string(input),
+		inliner.Config{KeepImportant: keepImportant},
+	)
 	if err != nil {
 		fmt.Println("Inlining error: ", err)
 		os.Exit(1)

--- a/inliner/element.go
+++ b/inliner/element.go
@@ -68,7 +68,7 @@ func (element *Element) addStyleRule(styleRule *StyleRule) {
 }
 
 // Inline styles on element
-func (element *Element) inline() error {
+func (element *Element) inline(keepImportant bool) error {
 	// compute declarations
 	declarations, err := element.computeDeclarations()
 	if err != nil {
@@ -76,7 +76,7 @@ func (element *Element) inline() error {
 	}
 
 	// set style attribute
-	styleValue := computeStyleValue(declarations)
+	styleValue := computeStyleValue(declarations, keepImportant)
 	if styleValue != "" {
 		element.elt.SetAttr("style", styleValue)
 	}
@@ -152,7 +152,7 @@ func (element *Element) setAttributesFromStyle(declarations []*css.Declaration) 
 }
 
 // helper
-func computeStyleValue(declarations []*css.Declaration) string {
+func computeStyleValue(declarations []*css.Declaration, keepImportant bool) string {
 	result := ""
 
 	// set style attribute value
@@ -161,7 +161,7 @@ func computeStyleValue(declarations []*css.Declaration) string {
 			result += " "
 		}
 
-		result += declaration.StringWithImportant(false)
+		result += declaration.StringWithImportant(keepImportant)
 	}
 
 	return result

--- a/inliner/inliner.go
+++ b/inliner/inliner.go
@@ -20,6 +20,11 @@ var unsupportedSelectors = []string{
 	":first-line", ":first-letter", ":focus", ":hover", ":invalid", ":in-range",
 	":lang", ":link", ":root", ":selection", ":target", ":valid", ":visited"}
 
+// Config configs the Inliner
+type Config struct {
+	KeepImportant bool
+}
+
 // Inliner presents a CSS Inliner
 type Inliner struct {
 	// Raw HTML
@@ -42,19 +47,27 @@ type Inliner struct {
 
 	// current element marker value
 	eltMarker int
+
+	config Config
 }
 
 // NewInliner instanciates a new Inliner
-func NewInliner(html string) *Inliner {
+func NewInliner(html string, config Config) *Inliner {
 	return &Inliner{
 		html:     html,
+		config:   config,
 		elements: make(map[string]*Element),
 	}
 }
 
 // Inline inlines css into html document
 func Inline(html string) (string, error) {
-	result, err := NewInliner(html).Inline()
+	return InlineWithConfig(html, Config{KeepImportant: false})
+}
+
+// InlineWithConfig inlines css into html document with configs specified
+func InlineWithConfig(html string, config Config) (string, error) {
+	result, err := NewInliner(html, config).Inline()
 	if err != nil {
 		return "", err
 	}
@@ -172,7 +185,7 @@ func (inliner *Inliner) inlineStyleRules() error {
 		element.elt.RemoveAttr(eltMarkerAttr)
 
 		// inline element
-		err := element.inline()
+		err := element.inline(inliner.config.KeepImportant)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Consider the case below:

```
<html>
  <head>
  <style type="text/css">
    .mycomponent {
      background-color: red;
      text-align: left !important;
    }

    @media screen (min-width: 600px) {
      .menu {
        text-align: center;
      }
    }
  }
  </style>
  </head>
  <body>
    <div class="mycomponent menu">Hello</div>
  </body>
</html>`

```
If we do not keep "!important" for "text-align" for rule .mycomponent,
it gets overriden by media query rule .menu.